### PR TITLE
Build swatch grids with document fragments

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,6 +246,8 @@
                     // Updated grid for square swatches
                     paletteSwatches.className = 'p-3 grid grid-cols-2 gap-2';
                     
+                    const paletteFragment = document.createDocumentFragment();
+
                     palette.forEach(comboColor => {
                         const swatch = document.createElement('div');
                         // Added relative and aspect-square for the new style
@@ -274,10 +276,12 @@
                             selectColor(comboColor);
                             window.scrollTo({ top: 0, behavior: 'smooth' });
                         });
-                        
-                        paletteSwatches.appendChild(swatch);
+
+                        paletteFragment.appendChild(swatch);
                     });
                     // --- END OF CHANGE ---
+
+                    paletteSwatches.appendChild(paletteFragment);
 
                     paletteCard.appendChild(paletteSwatches);
                     combinationsGrid.appendChild(paletteCard);
@@ -311,6 +315,8 @@
                 return;
             }
             // Populate the main grid with all colors
+            const swatchFragment = document.createDocumentFragment();
+
             colorsData.forEach(color => {
                 const swatch = document.createElement('div');
                 swatch.className = 'main-palette-swatch h-36 sm:h-48';
@@ -343,8 +349,10 @@
                     selectColor(color);
                     window.scrollTo({ top: 0, behavior: 'smooth' });
                 });
-                colorsGrid.appendChild(swatch);
+                swatchFragment.appendChild(swatch);
             });
+
+            colorsGrid.appendChild(swatchFragment);
 
             // Select the first color by default
             if (colorsData.length > 0) {


### PR DESCRIPTION
## Summary
- build the main color grid inside a document fragment before attaching it to the DOM
- assemble palette swatches for selected colors off-DOM before inserting the palette card

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1c7ead9a0832082c6d065b72c6da4