### PR TITLE
Remove width constraint from palette name spans

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,8 +337,8 @@
                 hexEl.textContent = color.hex;
 
                 const nameEl = document.createElement('span');
-                // CHANGE: Added w-1/2 to limit width and 'truncate' for ellipsis on long names
-                nameEl.className = 'swatch-info bottom-0 left-0 text-right w-1/2';
+                // Align the palette name along the bottom-left while keeping the text right-aligned
+                nameEl.className = 'swatch-info bottom-0 left-0 text-right';
                 nameEl.textContent = color.name;
 
                 swatch.appendChild(indexEl);


### PR DESCRIPTION
## Summary
- remove the Tailwind `w-1/2` class from the main palette name span to allow full-width rendering
- keep the span anchored bottom-left with right-aligned text for readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1d0fe5b4883208d3d74bc4176d1d7