### PR TITLE
Adjust mobile color grid columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
                 <!-- All Colors Grid -->
                 <div class="border-t pt-10">
                     <h3 class="text-xl lg:text-2xl font-semibold text-gray-800 mb-6">Complete Color Index</h3>
-                    <div id="colors-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-0">
+                    <div id="colors-grid" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 gap-0">
                         <!-- Color swatches will be inserted here -->
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- increase the base column count for the complete color index grid to three and scale up breakpoints for larger screens

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1d7c83058832090804e836d1dde0c